### PR TITLE
README.md: rm ref to zoxide's ranger code

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ map cz console z%space
 
 ## See Also
 
-- [zoxide/contrib/ranger.py](https://github.com/ajeetdsouza/zoxide/blob/master/contrib/ranger.py)
 - [ranger-zjumper](https://github.com/ask1234560/ranger-zjumper).
 
 ## License


### PR DESCRIPTION
zoxide's ranger code has been removed (in favor of referencing
ranger-zoxide). See https://github.com/ajeetdsouza/zoxide/commit/84c9121f1090ce216616340610dc7dce9fdc819d.