### PR TITLE
Add interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ Easily jump between commonly visited directories by running this in ranger:
 :z <partial-name>
 ```
 
+Or use interactive mode:
+
+```
+:zi <partial-name>
+```
+
 ## Features
 
 - Very simple &amp; fast thanks to zoxide
@@ -41,6 +47,12 @@ directories. Simply add a binding to your `~/.config/ranger/rc.conf` file:
 
 ```
 map cz console z%space
+```
+
+Or for interactive use:
+
+```
+map cz zi
 ```
 
 ## See Also

--- a/__init__.py
+++ b/__init__.py
@@ -26,17 +26,22 @@ class z(ranger.api.commands.Command):
     """
     def execute(self):
         results = self.query(self.args[1:])
+        if not results:
+            return
+
         if os.path.isdir(results[0]):
             self.fm.cd(results[0])
 
     def query(self, args):
         try:
-            p = Popen(
-                ["zoxide", "query"] + self.args[1:],
-                stdout=PIPE,
-                stderr=PIPE
+            p = self.fm.execute_command("zoxide query {}".format(" ".join(self.args[1:])),
+                stdout=PIPE
             )
             stdout, stderr = p.communicate()
+
+            if not stdout:
+                return None
+
             if p.returncode == 0:
                 output = stdout.decode("utf-8").strip()
                 if output:

--- a/__init__.py
+++ b/__init__.py
@@ -13,6 +13,7 @@ def hook_init(fm):
         process.wait()
 
     fm.signal_bind("cd", zoxide_add)
+    fm.commands.alias("zi", "z -i")
     return hook_init_prev(fm)
 
 
@@ -57,3 +58,4 @@ class z(ranger.api.commands.Command):
     def tab(self, tabnum):
         results = self.query(self.args[1:])
         return ["z {}".format(x) for x in results]
+


### PR DESCRIPTION
Hi, and thanks for the plugin!

This pull request adds the ability to use z in interactive mode, through `zi` or `z -i`.

As a note: I had to replace `Popen` with ranger's `execute_command` or the terminal would have problems redrawing.